### PR TITLE
feat!: create default config command

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-cargo r -- "$(cat $1)"
+cargo r -- lint "$(cat $1)"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,7 @@ dependencies = [
  "nom",
  "serde",
  "thiserror",
+ "toml",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ nom = "7.1.3"
 serde = { version = "1.0.207", features = ["derive"] }
 thiserror = "1.0.63"
 figment = { version = "0.10.19", features = ["toml"] }
+toml = "0.8.19"

--- a/README.md
+++ b/README.md
@@ -24,20 +24,20 @@ The binary will be located at `target/release/change-scribe`.
 To use `change-scribe`:
 
 ```sh
-change-scribe "fix: resolved that bug"
+change-scribe lint "fix: resolved that bug"
 ```
 
 This validates the message according to the default configuration. The commit
 message could also be passed via stdin:
 
 ```sh
-echo "fix: resolved that bug" | change-scribe -
+echo "fix: resolved that bug" | change-scribe lint -
 ```
 
 To apply a custom config, use the `--config` flag:
 
 ```sh
-change-scribe --config path/to/config.toml "fix: resolved that bug"
+change-scribe lint --config path/to/config.toml "fix: resolved that bug"
 ```
 
 By default, `change-scribe` reads configuration from either
@@ -75,7 +75,7 @@ Ensures that the commit type is at most the entered length.
 **Default**:
 
 ```toml
-type.max-length = 18446744073709551615
+type.max-length = 4294967295
 ```
 
 ### Scope

--- a/src/linting/commit_type.rs
+++ b/src/linting/commit_type.rs
@@ -18,7 +18,7 @@ impl Default for TypeConf {
         Self {
             types: vec!["*".to_string()],
             min_length: usize::MIN,
-            max_length: usize::MAX,
+            max_length: u32::MAX as usize,
         }
     }
 }

--- a/src/linting/mod.rs
+++ b/src/linting/mod.rs
@@ -44,7 +44,7 @@ enum LintErrorKind {
 }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
-struct Conf {
+pub(crate) struct Conf {
     #[serde(rename = "type")]
     commit_type: TypeConf,
     #[serde(rename = "scope")]


### PR DESCRIPTION
Changes lint command from `change-scribe` to `change-scribe lint`. Closes #7 